### PR TITLE
Round robin scheduler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,10 @@ KaguOS supports user-space programs that operate within restricted memory region
 | 12 (not impl)| SYS_CALL_GET_FILE_ATTR    | File descriptor     | -                   | -          | "7 7 7 user group"   | Error      |
 | 13 (not impl)| SYS_CALL_SET_FILE_ATTR    | File descriptor     | "4 4 0 user group"  | -          | -                    | Error      |
 | 14         | SYS_CALL_SCHED_PROGRAM    | Command line        | Priority            | -          | Process ID  | Error      |
+|     15       | SYS_CALL_IS_PROCESS_ACTIVE |   pid to check     |                   |                 |  process info         |  error if not active
+|     16       |   SYS_CALL_KILL_PROCESS |   pid to kill      |         -         |         -       |         -             |  error if no process
+|     17       | SYS_CALL_SKIP_SCHED     |         -          |         -         |         -       |         -             |   error if skip request was failed
+|     18       |    SYS_CALL_WAIT_SCHED     |         -          |         -         |         -       |         -             |    error if wait request failed
 
 ### 6.3 User Space Memory Management
 User-space programs execute within predefined memory regions. Process-related information is stored in:
@@ -861,7 +865,7 @@ config.txt main.disk 11 10
 ## 9. Scheduler
 
 ### 9.1 Approach to Process Scheduling
-In current version KaguOS schedules programs for execution by loading them into memory and executing them sequentially, one by one. Each process is allocated a predefined memory size, and the system ensures that processes do not exceed the configured limit.
+In current version KaguOS schedules programs for execution by loading them into memory and executing them with round robin. Each process is allocated a predefined memory size, and the system ensures that processes do not exceed the configured limit.
 
 The process control block (PCB) maintains process metadata, including memory allocation and execution state. The structure of a PCB entry is as follows:
 ```
@@ -931,6 +935,10 @@ write OP_SYS_CALL to REG_OP
 cpu_exec
 ```
 This call enables user-space programs to interact with the scheduler, dynamically adding new tasks to the execution queue.
+
+**NOTE**: You can use *SYS_CALL_IS_PROCESS_ACTIVE* and *SYS_CALL_KILL_PROCESS* to manage the process you scheduled. 
+You can use *SYS_CALL_SKIP_SCHED* to skip current quantum from scheduler. 
+Also you can use *SYS_CALL_WAIT_SCHED* to pause your process until other processes with state ready will be completed.
 
 ### 9.4 Debugging and Memory Dumping
 Debugging behavior has been adjusted in the new scheduling implementation. If `debug on` is enabled via the console, only user-space memory will be dumped and printed. The memory dump is now stored in `tmp/RAM_user.txt`. Additionally, the system can be launched with the `-u` flag to enable user-space-only memory dumping automatically.

--- a/hw/main.disk
+++ b/hw/main.disk
@@ -16,7 +16,7 @@ clear 7 7 7 user user BLOCKS 262 275
 debug 7 7 7 user user BLOCKS 276 320
 sleep 7 7 7 user user BLOCKS 321 335
 user_sched 7 7 7 user group BLOCKS 336 395
-
+minion 7 7 7 user user BLOCKS 396 547
 
 
 
@@ -31,7 +31,7 @@ FS_HEADER_END
 proc_memory 250     // memory allocated for one process
 max_proc_count 10   // max count of active processes
 max_fd_count 50     // max count of files open at the same time
-
+schedule_quantum 400 // instruction count before rescheduling
 
 
 
@@ -133,7 +133,7 @@ The end
 1 143 187      #  write "ccccccccccrrrccrrrcccccccccc" => 187
 1 144 188      #  write "cccccccccbbbccccbbbccccccccc" => 188
 1 145 189      #  write "ccccccccbbbbccccbbbbcccccccc" => 189
-1 146 190      #  write "cwwwwwwwwwwwwwwwwwwwwwwwwwwc" => 190
+1 146 190      #  write "cBBBBBBBBBBBBBBBBBBBBBBBBBBc" => 190
 1 129 191      #  write "cccccccccccccccccccccccccccc" => 191
 1 129 192      #  write "cccccccccccccccccccccccccccc" => 192
 1 129 193      #  write "cccccccccccccccccccccccccccc" => 193
@@ -237,7 +237,7 @@ ccccccccyyrrrrrrrryycccccccc
 ccccccccccrrrccrrrcccccccccc
 cccccccccbbbccccbbbccccccccc
 ccccccccbbbbccccbbbbcccccccc
-cwwwwwwwwwwwwwwwwwwwwwwwwwwc
+cBBBBBBBBBBBBBBBBBBBBBBBBBBc
 3
 0
 8
@@ -393,154 +393,154 @@ Program loaded with PID
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+1 4 165        #  copy REG_A => var:iterations
+1 126 4        #  write COLOR_CYAN => REG_A
+1 127 10       #  write SYS_CALL_SET_BACKGROUND => REG_D
+1 128 2        #  write OP_SYS_CALL => REG_OP
+0              #  cpu_exec
+1 129 170      #  write "cccccccccccccccccccccccccccc" => 170
+1 129 171      #  write "cccccccccccccccccccccccccccc" => 171
+1 129 172      #  write "cccccccccccccccccccccccccccc" => 172
+1 129 173      #  write "cccccccccccccccccccccccccccc" => 173
+1 130 174      #  write "ccccccccccyyyyyyycccccccccccc" => 174
+1 131 175      #  write "cccccccccyyyyyyyyyccccccccccc" => 175
+1 132 176      #  write "ccccccccyybbyyybbyyccccccccc" => 176
+1 133 177      #  write "ccccccccBbwBbBbwBbBccccccccc" => 177
+1 134 178      #  write "ccccccccBbwwbBbwwbBccccccccc" => 178
+1 135 179      #  write "ccccccccyybbyyybbyyccccccccc" => 179
+1 136 180      #  write "ccccccccyyyyyyyyyyycccccccccc" => 180
+1 137 181      #  write "ccccccccyyByyyyyByycccccccccc" => 181
+1 138 182      #  write "ccccccccyyyBBBBByyycccccccccc" => 182
+1 139 183      #  write "ccccccccbyyyyyyyyybcccccccccc" => 183
+1 140 184      #  write "ccccccccybbbbbbbbbycccccccccc" => 184
+1 141 185      #  write "ccccccccyybbbbbbbyycccccccccc" => 185
+1 141 186      #  write "ccccccccyybbbbbbbyycccccccccc" => 186
+1 140 187      #  write "ccccccccybbbbbbbbbycccccccccc" => 187
+1 142 188      #  write "cccccccBBbbbbbbbbbBBccccccccc" => 188
+1 143 189      #  write "ccccccccBbbbbbbbbbBcccccccccc" => 189
+1 144 190      #  write "ccccccccccBBcccBBcccccccccccc" => 190
+1 145 191      #  write "cccccccccBBBcccBBBccccccccccc" => 191
+1 129 192      #  write "cccccccccccccccccccccccccccc" => 192
+1 129 193      #  write "cccccccccccccccccccccccccccc" => 193
+1 129 194      #  write "cccccccccccccccccccccccccccc" => 194
+1 165 4        #  copy var:iterations => REG_A
+1 146 2        #  write OP_DECR => REG_OP
+0              #  cpu_exec
+1 12 165       #  copy REG_RES => var:iterations
+1 165 4        #  copy var:iterations => REG_A
+1 147 6        #  write "0" => REG_B
+1 148 2        #  write OP_CMP_EQ => REG_OP
+0              #  cpu_exec
+4 118          #  jump_if lbl:exit
+1 149 166      #  write "170" => var:counter
+1 166 4        #  copy var:counter => REG_A
+1 150 2        #  write OP_INCR => REG_OP
+0              #  cpu_exec
+1 12 166       #  copy REG_RES => var:counter
+1 166 4        #  copy var:counter => REG_A
+1 151 6        #  write "21" => REG_B
+1 152 2        #  write OP_ADD => REG_OP
+0              #  cpu_exec
+1 166 4        #  copy var:counter => REG_A
+1 12 6         #  copy REG_RES => REG_B
+1 153 10       #  write SYS_CALL_RENDER_BITMAP => REG_D
+1 128 2        #  write OP_SYS_CALL => REG_OP
+0              #  cpu_exec
+1 154 4        #  write "0.1" => REG_A
+1 155 10       #  write SYS_CALL_SLEEP => REG_D
+1 128 2        #  write OP_SYS_CALL => REG_OP
+0              #  cpu_exec
+1 166 4        #  copy var:counter => REG_A
+1 156 6        #  write "174" => REG_B
+1 157 2        #  write OP_CMP_NEQ => REG_OP
+0              #  cpu_exec
+4 57           #  jump_if lbl:loop_move_up
+1 166 4        #  copy var:counter => REG_A
+1 146 2        #  write OP_DECR => REG_OP
+0              #  cpu_exec
+1 12 166       #  copy REG_RES => var:counter
+1 166 4        #  copy var:counter => REG_A
+1 151 6        #  write "21" => REG_B
+1 152 2        #  write OP_ADD => REG_OP
+0              #  cpu_exec
+1 166 4        #  copy var:counter => REG_A
+1 12 6         #  copy REG_RES => REG_B
+1 153 10       #  write SYS_CALL_RENDER_BITMAP => REG_D
+1 128 2        #  write OP_SYS_CALL => REG_OP
+0              #  cpu_exec
+1 154 4        #  write "0.1" => REG_A
+1 155 10       #  write SYS_CALL_SLEEP => REG_D
+1 128 2        #  write OP_SYS_CALL => REG_OP
+0              #  cpu_exec
+1 149 4        #  write "170" => REG_A
+1 166 6        #  copy var:counter => REG_B
+1 158 2        #  write OP_CMP_LT => REG_OP
+0              #  cpu_exec
+4 79           #  jump_if lbl:loop_move_down
+1 149 166      #  write "170" => var:counter
+1 159 4        #  write "c" => REG_A
+1 *166 6       #  copy *var:counter => REG_B
+1 160 8        #  write "" => REG_C
+1 161 2        #  write OP_CONCAT_WITH => REG_OP
+0              #  cpu_exec
+1 12 *166      #  copy REG_RES => *var:counter
+1 166 4        #  copy var:counter => REG_A
+1 150 2        #  write OP_INCR => REG_OP
+0              #  cpu_exec
+1 12 166       #  copy REG_RES => var:counter
+1 166 4        #  copy var:counter => REG_A
+1 162 6        #  write "192" => REG_B
+1 158 2        #  write OP_CMP_LT => REG_OP
+0              #  cpu_exec
+4 102          #  jump_if lbl:shift_right
+3 47           #  jump lbl:start
+1 163 4        #  write COLOR_NO => REG_A
+1 127 10       #  write SYS_CALL_SET_BACKGROUND => REG_D
+1 128 2        #  write OP_SYS_CALL => REG_OP
+0              #  cpu_exec
+1 147 4        #  write "0" => REG_A
+1 164 10       #  write SYS_CALL_EXIT => REG_D
+1 128 2        #  write OP_SYS_CALL => REG_OP
+0              #  cpu_exec
+7
+9
+25
+cccccccccccccccccccccccccccc
+ccccccccccyyyyyyycccccccccccc
+cccccccccyyyyyyyyyccccccccccc
+ccccccccyybbyyybbyyccccccccc
+ccccccccBbwBbBbwBbBccccccccc
+ccccccccBbwwbBbwwbBccccccccc
+ccccccccyybbyyybbyyccccccccc
+ccccccccyyyyyyyyyyycccccccccc
+ccccccccyyByyyyyByycccccccccc
+ccccccccyyyBBBBByyycccccccccc
+ccccccccbyyyyyyyyybcccccccccc
+ccccccccybbbbbbbbbycccccccccc
+ccccccccyybbbbbbbyycccccccccc
+cccccccBBbbbbbbbbbBBccccccccc
+ccccccccBbbbbbbbbbBcccccccccc
+ccccccccccBBcccBBcccccccccccc
+cccccccccBBBcccBBBccccccccccc
+3
+0
+8
+170
+2
+21
+0
+10
+0.1
+11
+174
+9
+10
+c
+
+17
+192
+0
+0
 
 
 

--- a/include/operations.sh
+++ b/include/operations.sh
@@ -164,7 +164,7 @@ export OP_SET_BACKGROUND_COLOR=23
 # To draw bitmap specify address of first line with bitmap representation to REG_A,
 # first address after the last line of bitmap to REG_B, and OP_RENDER_BITMAP to REG_OP.
 # Call INSTR_CPU_EXEC to render the bitmap.
-# Each line should contain letters B(black), g(green), y(yellow), r(red), b(blue), m(magenta), c(cyan), w(white)
+# Each line should contain letters B(black), g(green), y(yellow), r(red), b(blue), m(magenta), c(cyan), w(white), o(orange), n(no color)
 # For example string ggyyrr will display a line with 2 green cells, 2 yellow cells and 2 red cells
 export OP_RENDER_BITMAP=24
 

--- a/include/syscalls.sh
+++ b/include/syscalls.sh
@@ -47,3 +47,20 @@ export SYS_CALL_SET_FILE_ATTR=13
 # Schedules a program for execution
 # REG_A contains command line to execute for example mario 10 or cat 1.txt, REG_B contains priority of the process
 export SYS_CALL_SCHED_PROGRAM=14
+
+# Check whether process with given pid exists
+# REG_A contains the pid of the process to be checked, REG_RES pcb info and REG_ERROR empty if active, error in REG_ERROR otherwise
+export SYS_CALL_IS_PROCESS_ACTIVE=15
+
+# Kill the process with the provided PID
+# REG_A contains the pid of the process to be killed, REG_ERROR if no process with pid
+export SYS_CALL_KILL_PROCESS=16
+
+# Ask scheduler to skip current quantum allocated for the process
+export SYS_CALL_SKIP_SCHED=17
+
+# Ask scheduler to postpone execution of the process untill all other processes will be completed
+export SYS_CALL_WAIT_SCHED=18
+
+
+

--- a/instructionSet.html
+++ b/instructionSet.html
@@ -231,7 +231,7 @@
         <td>Render bitmap</td>
         <td>OP_RENDER_BITMAP (24)</td>
         <td>REG_A, REG_B</td>
-        <td>Allows to print colored cells on the screen based on the provided bitmap. Set address of the first bitmap line to REG_A and the address after the last line to REG_B. Bitmap lines should contain only letters B(black), g(green), y(yellow), r(red), b(blue), m(magenta), c(cyan), w(white)</td>
+        <td>Allows to print colored cells on the screen based on the provided bitmap. Set address of the first bitmap line to REG_A and the address after the last line to REG_B. Bitmap lines should contain only letters B(black), g(green), y(yellow), r(red), b(blue), m(magenta), c(cyan), w(white), o(orange), n(no color)</td>
       </tr> 
       <tr>
         <td>No Operation</td>

--- a/src/kernel/02_fs.kga
+++ b/src/kernel/02_fs.kga
@@ -39,13 +39,6 @@ label sys_fs_init
     // Set default work dir to /
     write "/" to var:sys_work_dir
 
-    // At the earlier stage of boot we don't know the real count of descriptors
-    // as they are stored inside config file. But to open the file we need a memory for descriptor
-    // Let's temporary allocate address of one variable for that purpose
-    var sys_fs_init_helper_mem
-    write 1 to var:sys_fs_desc_max_count
-    copy @var:sys_fs_init_helper_mem to var:sys_fs_desc_start
-
     // Allocate memory for mount point information and parse it
     copy FREE_MEMORY_START to var:sys_fs_mounts_start
     write 0 to var:sys_fs_mounts_count
@@ -291,6 +284,12 @@ label sys_fs_init
         write OP_ADD to REG_OP
         cpu_exec
         copy REG_RES to FREE_MEMORY_START
+
+        // At the earlier stage of boot we don't know the real count of descriptors
+        // as they are stored inside config file. But to open the file we need a memory for descriptor
+        // Let's temporary allocate address in free memory for that purpose
+        write 2 to var:sys_fs_desc_max_count
+        copy FREE_MEMORY_START to var:sys_fs_desc_start
 
         jump label:sys_stack_pop
 

--- a/src/kernel/03_syscalls.kga
+++ b/src/kernel/03_syscalls.kga
@@ -15,6 +15,10 @@
 //     12       |  get_file_attr    |  file descriptor   |        -          |        -        |  "7 7 7 user group"   |     error
 //     13       |  set_file_attr    |  file descriptor   |  "4 4 0 user grp" |        -        |            -          |     error
 //     14       |  sched_program    |  command line      |    priority       |        -        |  process ID           |     error
+//     15       | is_process_active |   pid to check     |                   |                 |  process info         |  error if not active
+//     16       |   kill_process    |   pid to kill      |         -         |         -       |         -             |  error if no process
+//     17       |    skip_sched     |         -          |         -         |         -       |         -             |  error if skip failed
+//     18       |    wait_sched     |         -          |         -         |         -       |         -             |  error if wait failed
 
 var sys_call_count
 var sys_call_00
@@ -32,6 +36,10 @@ var sys_call_11
 var sys_call_12
 var sys_call_13
 var sys_call_14
+var sys_call_15
+var sys_call_16
+var sys_call_17
+var sys_call_18
 
 
 label sys_call_handler
@@ -93,6 +101,17 @@ label sys_call_to_user_mode
 
 // SYSTEM CALLS IMPLEMENTATION START
 label sys_call_exit
+    // As this system call stops the process, we should adjust interrupt data to set ignore custom result registers
+    // This will ensure that the next running process will not be impacted by any results of this system call
+    // NOTE: interrupt data format <id> <program counter> <ignore result registers flag>
+    copy REG_SYS_INTERRUPT_DATA to REG_A
+    write 3 to REG_B
+    write " " to REG_C
+    write 1 to REG_D
+    write OP_REPLACE_COLUMN to REG_OP
+    cpu_exec
+    copy REG_RES to REG_SYS_INTERRUPT_DATA
+
     copy PROGRAM_COUNTER to var:sys_return
     jump label:sys_sched_process_stop
 
@@ -244,8 +263,40 @@ label sys_call_sched_program
     copy var:sys_call_arg2 to REG_B
     copy PROGRAM_COUNTER to var:sys_return
     jump label:sys_sched_process_load
-
     jump label:sys_call_to_user_mode
+
+
+
+label sys_call_is_active_pid
+    copy var:sys_call_arg1 to REG_A
+    copy PROGRAM_COUNTER to var:sys_return
+    jump label:sys_sched_is_active_pid
+    jump label:sys_call_to_user_mode
+
+
+
+label sys_call_kill_process
+    copy var:sys_call_arg1 to REG_A
+    copy PROGRAM_COUNTER to var:sys_return
+    jump label:sys_sched_kill_pid
+    jump label:sys_call_to_user_mode
+
+
+
+
+label sys_call_skip_sched
+    copy PROGRAM_COUNTER to var:sys_return
+    jump label:sys_sched_skip_sched
+    jump label:sys_call_to_user_mode
+
+
+
+
+label sys_call_wait_sched
+    copy PROGRAM_COUNTER to var:sys_return
+    jump label:sys_sched_wait_sched
+    jump label:sys_call_to_user_mode
+
 
 // SYSTEM CALLS IMPLEMENTATION END
 
@@ -260,7 +311,7 @@ label sys_call_table_init
     jump label:sys_stack_push
 
     write label:sys_call_handler to REG_SYS_CALL_HANDLER
-    write 15 to var:sys_call_count
+    write 19 to var:sys_call_count
 
     write label:sys_call_exit to var:sys_call_00
     write label:sys_call_println to var:sys_call_01
@@ -277,4 +328,9 @@ label sys_call_table_init
     write label:sys_call_get_file_attr to var:sys_call_12
     write label:sys_call_set_file_attr to var:sys_call_13
     write label:sys_call_sched_program to var:sys_call_14
+    write label:sys_call_is_active_pid to var:sys_call_15
+    write label:sys_call_kill_process to var:sys_call_16
+    write label:sys_call_skip_sched to var:sys_call_17
+    write label:sys_call_wait_sched to var:sys_call_18
+
     jump label:sys_stack_pop

--- a/src/kernel/04_sched.kga
+++ b/src/kernel/04_sched.kga
@@ -8,48 +8,125 @@ var sys_proc_max_count
 var sys_last_used_pid
 var sys_cur_pcb_ptr
 var sys_pcb_free_mem_list
+var sys_sched_time_quantum
 
+label sys_interrupt_handler
+    // Backup registers to the local variables:
+        var sys_int_hndl_reg_op
+        copy REG_OP to var:sys_int_hndl_reg_op
+        var sys_int_hndl_reg_a
+        copy REG_A to var:sys_int_hndl_reg_a
+        var sys_int_hndl_reg_b
+        copy REG_B to var:sys_int_hndl_reg_b
+        var sys_int_hndl_reg_c
+        copy REG_C to var:sys_int_hndl_reg_c
+        var sys_int_hndl_reg_d
+        copy REG_D to var:sys_int_hndl_reg_d
+        var sys_int_hndl_reg_res
+        copy REG_RES to var:sys_int_hndl_reg_res
+        var sys_int_hndl_reg_bool_res
+        copy REG_BOOL_RES to var:sys_int_hndl_reg_bool_res
+        var sys_int_hndl_reg_error
+        copy REG_ERROR to var:sys_int_hndl_reg_error
+
+    // copy values of the registers to the process memory:
+        // add 2 to get REG_OP address of process to set a backup
+        copy REG_PROC_START_ADDRESS to REG_A
+        write 2 to REG_B
+        write OP_ADD to REG_OP
+        cpu_exec
+        copy var:sys_int_hndl_reg_op to *REG_RES
+
+        // add 4 to get REG_A address of process to set a backup
+        // copy REG_PROC_START_ADDRESS to REG_A
+        write 4 to REG_B
+        // write OP_ADD to REG_OP
+        cpu_exec
+        copy var:sys_int_hndl_reg_a to *REG_RES
+
+        // add 6 to get REG_B address of process to set a backup
+        // copy REG_PROC_START_ADDRESS to REG_A
+        write 6 to REG_B
+        // write OP_ADD to REG_OP
+        cpu_exec
+        copy var:sys_int_hndl_reg_b to *REG_RES
+
+        // add 8 to get REG_C address of process to set a backup
+        // copy REG_PROC_START_ADDRESS to REG_A
+        write 8 to REG_B
+        // write OP_ADD to REG_OP
+        cpu_exec
+        copy var:sys_int_hndl_reg_c to *REG_RES
+
+        // add 10 to get REG_D address of process to set a backup
+        // copy REG_PROC_START_ADDRESS to REG_A
+        write 10 to REG_B
+        // write OP_ADD to REG_OP
+        cpu_exec
+        copy var:sys_int_hndl_reg_d to *REG_RES
+
+        // add 12 to get REG_RES address of process to set a backup
+        // copy REG_PROC_START_ADDRESS to REG_A
+        write 12 to REG_B
+        // write OP_ADD to REG_OP
+        cpu_exec
+        copy var:sys_int_hndl_reg_res to *REG_RES
+
+        // add 14 to get REG_BOOL_RES address of process to set a backup
+        // copy REG_PROC_START_ADDRESS to REG_A
+        write 14 to REG_B
+        // write OP_ADD to REG_OP
+        cpu_exec
+        copy var:sys_int_hndl_reg_bool_res to *REG_RES
+
+        // add 16 to get REG_ERROR address of process to set a backup
+        // copy REG_PROC_START_ADDRESS to REG_A
+        write 16 to REG_B
+        // write OP_ADD to REG_OP
+        cpu_exec
+        copy var:sys_int_hndl_reg_error to *REG_RES
+
+    // Analyze interrupt info and reschedule the processes
+        // As of now we support only hardware timer interrupt(code 1) to be handled by this code:
+        copy REG_SYS_INTERRUPT_DATA to REG_A
+        write 1 to REG_B
+        write " " to REG_C
+        write OP_GET_COLUMN to REG_OP
+        cpu_exec
+        copy REG_RES to REG_A
+        // write 1 to REG_B
+        write OP_CMP_EQ to REG_OP
+        cpu_exec
+        jump_if_not label:kernel_panic
+
+        copy REG_SYS_INTERRUPT_DATA to REG_A
+        write 2 to REG_B
+        write " " to REG_C
+        write OP_GET_COLUMN to REG_OP
+        cpu_exec
+
+        copy *var:sys_cur_pcb_ptr to REG_A
+        write 14 to REG_B
+        write " " to REG_C
+        copy REG_RES to REG_D // set updated program counter to process control block
+        write OP_REPLACE_COLUMN to REG_OP
+        cpu_exec
+        copy REG_RES to *var:sys_cur_pcb_ptr
+
+        jump label:sys_sched_run
 
 label sys_sched_run
     var sys_sched_run_cur_pcb
     write "" to var:sys_sched_run_cur_pcb
 
-    var sys_sched_run_ptr
-    copy var:sys_pcb_list_start to var:sys_sched_run_ptr
-    label sys_sched_check_ready_loop
-        // Get state and check whether it is ready:
-        copy *var:sys_sched_run_ptr to REG_A
-        write 6 to REG_B
-        write " " to REG_C
-        write OP_GET_COLUMN to REG_OP
-        cpu_exec
-        copy REG_RES to REG_PROC_START_ADDRESS
+    // Let's call an algorithm to find the next process ready for execution
+    copy PROGRAM_COUNTER to var:sys_return
+    jump label:sys_sched_select_next
+    jump_err label:sys_sched_run_no_process
+    copy REG_RES to var:sys_cur_pcb_ptr
+    copy *var:sys_cur_pcb_ptr to var:sys_sched_run_cur_pcb
 
-        copy REG_RES to REG_A
-        write "ready" to REG_B
-        write OP_CMP_EQ to REG_OP
-        cpu_exec
-        jump_if label:sys_sched_found_ready
-
-        // If not, increment pointer and check whether we have other PCB
-        copy var:sys_sched_run_ptr to REG_A
-        write OP_INCR to REG_OP
-        cpu_exec
-        copy REG_RES to var:sys_sched_run_ptr
-
-        copy var:sys_sched_run_ptr to REG_A
-        copy var:sys_pcb_list_end to REG_B
-        write OP_CMP_EQ to REG_OP
-        cpu_exec
-        jump_if_not label:sys_sched_check_ready_loop
-
-        jump label:kernel_start
-
-
-    label sys_sched_found_ready
-        copy var:sys_sched_run_ptr to var:sys_cur_pcb_ptr
-        copy *var:sys_cur_pcb_ptr to var:sys_sched_run_cur_pcb
-
+    // Parse process control block to set it's address range and program counter to the proper registers:
     // Get memory start address:
     copy var:sys_sched_run_cur_pcb to REG_A
     write 10 to REG_B
@@ -69,11 +146,142 @@ label sys_sched_run
     write 14 to REG_B
     // write OP_GET_COLUMN to REG_OP
     cpu_exec
-    copy REG_RES to REG_SYS_RET_ADDRESS
+    var sys_sched_run_pc
+    copy REG_RES to var:sys_sched_run_pc
 
+    copy REG_SYS_INTERRUPT_DATA to REG_A
+    write "" to REG_B
+    write OP_CMP_EQ to REG_OP
+    jump_if_not label:sys_sched_run_adjust_interrupt_data
+    write "0 0 1" to REG_SYS_INTERRUPT_DATA // set default interrupt data for further adjustment
+
+    // Let's update interrupt data with new program counter for return address:
+    label sys_sched_run_adjust_interrupt_data
+        copy REG_SYS_INTERRUPT_DATA to REG_A
+        write 2 to REG_B
+        write " " to REG_C
+        copy var:sys_sched_run_pc to REG_D
+        write OP_REPLACE_COLUMN to REG_OP
+        cpu_exec
+        copy REG_RES to REG_SYS_INTERRUPT_DATA
+
+    // Set the count of ticks for hardware timer to get HW clock interrupt in the future.
+    // Therefore the next rescheduling will be done when timer generates an interrupt
+    // or the process will exit or ask for reschedule by itself
+    copy var:sys_sched_time_quantum to REG_SYS_HW_TIMER
     write OP_SYS_RETURN to REG_OP
     cpu_exec
 
+    label sys_sched_run_no_process
+        // if we didn't find process ready for execution, exit from scheduling
+        write "" to var:sys_cur_pcb_ptr
+        jump label:kernel_start
+
+
+
+// This function allows to find the next process to be executed
+// RETURN:
+//      REG_RES contains a pointer to the process control block of the next process to be executed
+//      REG_ERROR if no process was found for scheduling
+label sys_sched_select_next
+    copy PROGRAM_COUNTER to var:sys_stack_return
+    jump label:sys_stack_push
+
+    // We are using our list of processes as a ring buffer.
+    // If no active process, start check with sys_pcb_list_start element
+    // otherwise start search from the process which is the next to the current
+    // so current process will be the last option to choose
+    var sys_sched_select_next_ptr
+    copy var:sys_cur_pcb_ptr to var:sys_sched_select_next_ptr
+    copy var:sys_sched_select_next_ptr to REG_A
+    write "" to REG_B
+    write OP_CMP_EQ to REG_OP
+    cpu_exec
+    jump_if label:sys_sched_select_next_no_cur_pcb
+
+    // Let's start search from the next index after the current process:
+    copy var:sys_sched_select_next_ptr to REG_A
+    write OP_INCR to REG_OP
+    cpu_exec
+    copy REG_RES to var:sys_sched_select_next_ptr
+    jump label:sys_sched_select_next_set_counter
+
+    label sys_sched_select_next_no_cur_pcb
+        // No active process, let's start search from the first process control block:
+        copy var:sys_pcb_list_start to var:sys_sched_select_next_ptr
+
+    label sys_sched_select_next_set_counter
+        var sys_sched_select_next_counter
+        write 0 to var:sys_sched_select_next_counter
+
+    label sys_sched_check_ready_loop
+        // if var:sys_sched_select_next_ptr == var:sys_pcb_list_end,
+        // reset to check the first element in the list
+        copy var:sys_sched_select_next_ptr to REG_A
+        copy var:sys_pcb_list_end to REG_B
+        write OP_CMP_EQ to REG_OP
+        cpu_exec
+        jump_if_not label:sys_sched_check_ready
+        copy var:sys_pcb_list_start to var:sys_sched_select_next_ptr
+
+        // Get state and check it; if state is "ready", we found the next process to run:
+        label sys_sched_check_ready
+            copy *var:sys_sched_select_next_ptr to REG_A
+            write 6 to REG_B
+            write " " to REG_C
+            write OP_GET_COLUMN to REG_OP
+            cpu_exec
+
+            copy REG_RES to REG_A
+            write "ready" to REG_B
+            write OP_CMP_EQ to REG_OP
+            cpu_exec
+            jump_if label:sys_sched_found_ready
+
+        label sys_sched_select_next_proceed
+            // Increment counter and current pcb pointer;
+            // determine whether we check all the processes
+            copy var:sys_sched_select_next_ptr to REG_A
+            write OP_INCR to REG_OP
+            cpu_exec
+            copy REG_RES to var:sys_sched_select_next_ptr
+
+            copy var:sys_sched_select_next_counter to REG_A
+            // write OP_INCR to REG_OP
+            cpu_exec
+            copy REG_RES to var:sys_sched_select_next_counter
+
+            copy var:sys_sched_select_next_counter to REG_A
+            copy var:sys_proc_max_count to REG_B
+            write OP_CMP_EQ to REG_OP
+            cpu_exec
+            jump_if_not label:sys_sched_check_ready_loop
+
+    // If no processes to run, let's try to activate paused processes
+    // and restart search algorithm
+    copy PROGRAM_COUNTER to var:sys_return
+    jump label:sys_sched_pause_to_ready
+    jump_err label:sys_sched_found_no
+    jump label:sys_sched_select_next_no_cur_pcb
+
+    label sys_sched_found_no
+        write "" to REG_RES
+        write "No process to schedule" to REG_ERROR
+        jump label:sys_stack_pop
+
+    label sys_sched_found_ready
+        copy var:sys_sched_select_next_ptr to REG_RES
+        write "" to REG_ERROR
+        jump label:sys_stack_pop
+
+
+label sys_sched_skip_sched
+    copy PROGRAM_COUNTER to var:sys_stack_return
+    jump label:sys_stack_push
+    write 0 to REG_SYS_HW_TIMER
+    write "" to REG_RES
+    write "" to REG_ERROR
+    jump label:sys_stack_pop
 
 
 label sys_sched_print_all
@@ -89,20 +297,27 @@ label sys_sched_print_all
         write " " to REG_C
         write OP_GET_COLUMN to REG_OP
         cpu_exec
-        copy REG_RES to REG_PROC_START_ADDRESS
 
         copy REG_RES to REG_A
         write "ready" to REG_B
         write OP_CMP_EQ to REG_OP
         cpu_exec
-        jump_if_not label:sys_sched_print_all_skip
+        jump_if label:sys_sched_print_all_display
 
-        copy *var:sys_sched_print_all_ptr to DISPLAY_BUFFER
-        write COLOR_CYAN to DISPLAY_COLOR
-        write OP_DISPLAY_LN to REG_OP
+        // copy REG_A to REG_A
+        write "pause" to REG_B
+        write OP_CMP_EQ to REG_OP
         cpu_exec
+        jump_if label:sys_sched_print_all_display
+        jump label:sys_sched_print_all_increment_counter
 
-        label sys_sched_print_all_skip
+        label sys_sched_print_all_display
+            copy *var:sys_sched_print_all_ptr to DISPLAY_BUFFER
+            write COLOR_CYAN to DISPLAY_COLOR
+            write OP_DISPLAY_LN to REG_OP
+            cpu_exec
+
+        label sys_sched_print_all_increment_counter
             copy var:sys_sched_print_all_ptr to REG_A
             write OP_INCR to REG_OP
             cpu_exec
@@ -116,7 +331,6 @@ label sys_sched_print_all
             jump label:sys_sched_check_print_all_loop
 
     jump label:sys_stack_pop
-
 
 
 
@@ -507,66 +721,15 @@ label sys_sched_process_load
 
 label sys_sched_process_stop
     // Let's clean the memory
-    copy REG_PROC_START_ADDRESS to REG_A
-    copy REG_PROC_END_ADDRESS to REG_B
-    label sys_sched_process_stop_loop
-        write "" to *REG_A
+    copy var:sys_cur_pcb_ptr to REG_A
+    copy PROGRAM_COUNTER to var:sys_return
+    jump label:sys_sched_clean_pcb
 
-        // Increment pointer in REG_A
-        // address that was just cleaned is already in REG_A
-        write OP_INCR to REG_OP
-        cpu_exec
+    write "" to REG_PROC_START_ADDRESS
+    write "" to REG_PROC_END_ADDRESS
+    write "" to var:sys_cur_pcb_ptr
 
-        // check whether it is still <= REG_PROC_END_ADDRESS
-        copy REG_RES to REG_A
-        // copy REG_PROC_END_ADDRESS to REG_B
-        write OP_CMP_LT to REG_OP
-        cpu_exec
-        jump_if label:sys_sched_process_stop_loop
-
-    // File descriptors cleanup
-    var sys_sched_process_stop_cur_pcb
-    var sys_sched_process_stop_counter
-    copy *var:sys_cur_pcb_ptr to var:sys_sched_process_stop_cur_pcb
-    write 16 to var:sys_sched_process_stop_counter
-    label sys_sched_process_stop_fd_loop
-        copy var:sys_sched_process_stop_cur_pcb to REG_A
-        copy var:sys_sched_process_stop_counter to REG_B
-        write " " to REG_C
-        write OP_GET_COLUMN to REG_OP
-        cpu_exec
-
-        copy REG_RES to REG_A
-        write "" to REG_B
-        write OP_CMP_EQ to REG_OP
-        cpu_exec
-        jump_if label:sys_sched_process_stop_finalize
-
-        // copy REG_RES to REG_A
-        copy PROGRAM_COUNTER to var:sys_return
-        jump label:sys_fs_close
-
-        copy var:sys_sched_process_stop_counter to REG_A
-        write OP_INCR to REG_OP
-        cpu_exec
-        copy REG_RES to var:sys_sched_process_stop_counter
-
-        jump label:sys_sched_process_stop_fd_loop
-
-    label sys_sched_process_stop_finalize
-        // let's mark the memory from the process as free for further reuse
-        copy REG_PROC_START_ADDRESS to REG_A
-        copy var:sys_pcb_free_mem_list to REG_B
-        write " " to REG_C
-        write OP_CONCAT_WITH to REG_OP
-        cpu_exec
-        copy REG_RES to var:sys_pcb_free_mem_list
-
-        write "" to REG_PROC_START_ADDRESS
-        write "" to REG_PROC_END_ADDRESS
-        write "0" to *var:sys_cur_pcb_ptr
-
-        jump label:sys_sched_run
+    jump label:sys_sched_run
 
 
 
@@ -677,4 +840,278 @@ label sys_remove_unneeded_spaces
 
     label sys_remove_unneeded_spaces_done
         copy REG_A to REG_RES
+        jump label:sys_stack_pop
+
+
+
+// Input: REG_A - pid of the process
+// RESULT: REG_RES address of process control block for PID, RES_ERROR set if not found
+label sys_sched_pid_to_pcb
+    copy PROGRAM_COUNTER to var:sys_stack_return
+    jump label:sys_stack_push
+
+    var sys_sched_pid_to_pcb_PID
+    copy REG_A to var:sys_sched_pid_to_pcb_PID
+
+    var sys_sched_pid_to_pcb_ptr
+    copy var:sys_pcb_list_start to var:sys_sched_pid_to_pcb_ptr
+    label sys_sched_pid_to_pcb_loop
+        copy *var:sys_sched_pid_to_pcb_ptr to REG_A
+        write 2 to REG_B
+        write " " to REG_C
+        write OP_GET_COLUMN to REG_OP
+        cpu_exec
+
+        copy REG_RES to REG_A
+        copy var:sys_sched_pid_to_pcb_PID to REG_B
+        write OP_CMP_EQ to REG_OP
+        cpu_exec
+        jump_if label:sys_sched_pid_to_pcb_found
+
+        copy var:sys_sched_pid_to_pcb_ptr to REG_A
+        write OP_INCR to REG_OP
+        cpu_exec
+        copy REG_RES to var:sys_sched_pid_to_pcb_ptr
+
+        copy var:sys_sched_pid_to_pcb_ptr to REG_A
+        copy var:sys_pcb_list_end to REG_B
+        write OP_CMP_LT to REG_OP
+        cpu_exec
+        jump_if label:sys_sched_pid_to_pcb_loop
+
+    // If no process with PID found let's return an error
+    write "" to REG_RES
+    write "No active process with provided PID found" to REG_ERROR
+    jump label:sys_stack_pop
+
+    label sys_sched_pid_to_pcb_found
+        copy var:sys_sched_pid_to_pcb_ptr to REG_RES
+        write "" to REG_ERROR
+        jump label:sys_stack_pop
+
+
+
+
+label sys_sched_is_active_pid
+    copy PROGRAM_COUNTER to var:sys_stack_return
+    jump label:sys_stack_push
+
+    // copy REG_A to REG_A
+    copy PROGRAM_COUNTER to var:sys_return
+    jump label:sys_sched_pid_to_pcb
+    jump_err label:sys_sched_is_active_not_found
+
+    copy *REG_RES to REG_RES
+    write "" to REG_ERROR
+    jump label:sys_stack_pop
+
+    // If no process with PID found let's return an error
+    label sys_sched_is_active_not_found
+        write "" to REG_RES
+        write "No active process with provided PID found" to REG_ERROR
+        jump label:sys_stack_pop
+
+
+
+
+// The main purpose of this function to allow the current process to postpone its own execution
+label sys_sched_wait_sched
+    copy PROGRAM_COUNTER to var:sys_stack_return
+    jump label:sys_stack_push
+
+    copy var:sys_cur_pcb_ptr to REG_A
+    write "" to REG_B
+    write OP_CMP_EQ to REG_OP
+    cpu_exec
+    jump_if label:sys_sched_wait_sched_error
+
+    copy *var:sys_cur_pcb_ptr  to REG_A
+    write 6 to REG_B
+    write " " to REG_C
+    write "pause" to REG_D
+    write OP_REPLACE_COLUMN to REG_OP
+    cpu_exec
+    copy REG_RES to *var:sys_cur_pcb_ptr
+
+    // Let's skip further execution of this process
+    copy PROGRAM_COUNTER to var:sys_return
+    jump label:sys_sched_skip_sched
+    jump label:sys_stack_pop
+
+    label sys_sched_wait_sched_error
+        write "" to REG_RES
+        write "Something wrong happened. No way to pause the process." to REG_ERROR
+        jump label:sys_stack_pop
+
+
+
+label sys_sched_pause_to_ready
+    copy PROGRAM_COUNTER to var:sys_stack_return
+    jump label:sys_stack_push
+
+    var sys_sched_pause_to_ready_error
+    write "Not found process with pause state" to var:sys_sched_pause_to_ready_error
+
+    var sys_sched_pause_to_ready_ptr
+    copy var:sys_pcb_list_start to var:sys_sched_pause_to_ready_ptr
+    label sys_sched_pause_to_ready_loop
+        copy *var:sys_sched_pause_to_ready_ptr to REG_A
+        write 6 to REG_B
+        write " " to REG_C
+        write OP_GET_COLUMN to REG_OP
+        cpu_exec
+
+        copy REG_RES to REG_A
+        write "pause" to REG_B
+        write OP_CMP_EQ to REG_OP
+        cpu_exec
+        jump_if_not label:sys_sched_pause_to_ready_proceed
+
+        // If we fouund at least one paused process, reset error
+        write "" to var:sys_sched_pause_to_ready_error
+
+        copy *var:sys_sched_pause_to_ready_ptr  to REG_A
+        write 6 to REG_B
+        write " " to REG_C
+        write "ready" to REG_D
+        write OP_REPLACE_COLUMN to REG_OP
+        cpu_exec
+        copy REG_RES to *var:sys_sched_pause_to_ready_ptr
+
+        label sys_sched_pause_to_ready_proceed
+            copy var:sys_sched_pause_to_ready_ptr to REG_A
+            write OP_INCR to REG_OP
+            cpu_exec
+            copy REG_RES to var:sys_sched_pause_to_ready_ptr
+
+            copy var:sys_sched_pause_to_ready_ptr to REG_A
+            copy var:sys_pcb_list_end to REG_B
+            write OP_CMP_LT to REG_OP
+            cpu_exec
+            jump_if label:sys_sched_pause_to_ready_loop
+
+    write "" to REG_RES
+    copy var:sys_sched_pause_to_ready_error to REG_ERROR
+    jump label:sys_stack_pop
+
+label sys_sched_kill_pid
+    copy PROGRAM_COUNTER to var:sys_stack_return
+    jump label:sys_stack_push
+
+    // copy REG_A to REG_A
+    copy PROGRAM_COUNTER to var:sys_return
+    jump label:sys_sched_pid_to_pcb
+    jump_err label:sys_sched_kill_pid_not_found
+
+    var sys_sched_kill_pid_pcb
+    copy REG_RES to var:sys_sched_kill_pid_pcb
+
+    copy var:sys_sched_kill_pid_pcb to REG_A
+    copy var:sys_cur_pcb_ptr to REG_B
+    write OP_CMP_EQ to REG_OP
+    cpu_exec
+    jump_if label:sys_sched_kill_pid_current
+
+    copy REG_RES to REG_A
+    copy PROGRAM_COUNTER to var:sys_return
+    jump label:sys_sched_clean_pcb
+    write "" to REG_RES
+    write "" to REG_ERROR
+    jump label:sys_stack_pop
+
+    label sys_sched_kill_pid_not_found
+        write "" to REG_RES
+        write "No active process with provided PID found" to REG_ERROR
+        jump label:sys_stack_pop
+
+    label sys_sched_kill_pid_current
+        write "" to REG_RES
+        write "Process can not use kill PID for its own PID" to REG_ERROR
+        jump label:sys_stack_pop
+
+
+
+// Function to clean process control block together with the process memory
+// Input: REG_A - address of process control block
+label sys_sched_clean_pcb
+    copy PROGRAM_COUNTER to var:sys_stack_return
+    jump label:sys_stack_push
+
+    var sys_sched_clean_pcb_ptr
+    copy REG_A to var:sys_sched_clean_pcb_ptr
+
+    var sys_sched_clean_pcb_start_mem
+    copy *var:sys_sched_clean_pcb_ptr to REG_A
+    write 10 to REG_B
+    write " " to REG_C
+    write OP_GET_COLUMN to REG_OP
+    cpu_exec
+    copy REG_RES to var:sys_sched_clean_pcb_start_mem
+
+    var sys_sched_clean_pcb_end_mem
+    // copy *var:sys_sched_clean_pcb_ptr to REG_A
+    write 12 to REG_B
+    // write " " to REG_C
+    // write OP_GET_COLUMN to REG_OP
+    cpu_exec
+    copy REG_RES to var:sys_sched_clean_pcb_end_mem
+
+    copy var:sys_sched_clean_pcb_start_mem to REG_A
+    copy var:sys_sched_clean_pcb_end_mem to REG_B
+    label sys_sched_clean_pcb_loop
+        write "" to *REG_A
+
+        // Increment pointer in REG_A
+        // address that was just cleaned is already in REG_A
+        write OP_INCR to REG_OP
+        cpu_exec
+
+        // check whether it is still <= REG_PROC_END_ADDRESS
+        copy REG_RES to REG_A
+        // copy REG_PROC_END_ADDRESS to REG_B
+        write OP_CMP_LT to REG_OP
+        cpu_exec
+        jump_if label:sys_sched_clean_pcb_loop
+
+    // File descriptors cleanup
+    var sys_sched_clean_pcb_cur_pcb
+    var sys_sched_clean_pcb_counter
+    copy *var:sys_sched_clean_pcb_ptr to var:sys_sched_clean_pcb_cur_pcb
+    write 16 to var:sys_sched_clean_pcb_counter
+    label sys_sched_clean_pcb_fd_loop
+        copy var:sys_sched_clean_pcb_cur_pcb to REG_A
+        copy var:sys_sched_clean_pcb_counter to REG_B
+        write " " to REG_C
+        write OP_GET_COLUMN to REG_OP
+        cpu_exec
+
+        copy REG_RES to REG_A
+        write "" to REG_B
+        write OP_CMP_EQ to REG_OP
+        cpu_exec
+        jump_if label:sys_sched_clean_pcb_finalize
+
+        // copy REG_RES to REG_A
+        copy PROGRAM_COUNTER to var:sys_return
+        jump label:sys_fs_close
+
+        copy var:sys_sched_clean_pcb_counter to REG_A
+        write OP_INCR to REG_OP
+        cpu_exec
+        copy REG_RES to var:sys_sched_clean_pcb_counter
+
+        jump label:sys_sched_clean_pcb_fd_loop
+
+    label sys_sched_clean_pcb_finalize
+        // let's mark the memory from the process as free for further reuse
+        copy var:sys_sched_clean_pcb_start_mem to REG_A
+        copy var:sys_pcb_free_mem_list to REG_B
+        write " " to REG_C
+        write OP_CONCAT_WITH to REG_OP
+        cpu_exec
+        copy REG_RES to var:sys_pcb_free_mem_list
+
+        write "0" to *var:sys_sched_clean_pcb_ptr
+        write "" to REG_RES
+        write "" to REG_ERROR
         jump label:sys_stack_pop

--- a/src/kernel/05_config.kga
+++ b/src/kernel/05_config.kga
@@ -15,6 +15,7 @@ label sys_read_config
     write 250 to var:sys_proc_memory_size
     write 10 to var:sys_proc_max_count
     write 50 to var:sys_fs_desc_max_count
+    write 50 to var:sys_sched_time_quantum
 
     // Open config file:
     var sys_read_config_fd
@@ -87,6 +88,12 @@ label sys_read_config
         cpu_exec
         jump_if label:sys_read_config_max_fd_count
 
+        // copy var:sys_read_config_name to REG_A
+        write "schedule_quantum" to REG_B
+        // write OP_CMP_EQ to REG_OP
+        cpu_exec
+        jump_if label:sys_read_config_sched_quantum
+
         jump label:sys_read_config_loop // return to the start of the loop
 
         label sys_read_config_proc_memory
@@ -99,6 +106,10 @@ label sys_read_config
 
         label sys_read_config_max_fd_count
             copy var:sys_read_config_value to var:sys_fs_desc_max_count
+            jump label:sys_read_config_loop
+
+        label sys_read_config_sched_quantum
+            copy var:sys_read_config_value to var:sys_sched_time_quantum
             jump label:sys_read_config_loop
 
     // close config and return from the function

--- a/src/kernel/09_kernel_base.kga
+++ b/src/kernel/09_kernel_base.kga
@@ -48,6 +48,10 @@ jump label:sys_read_config
 copy PROGRAM_COUNTER to var:sys_return
 jump label:sys_prepare_memory
 
+// Setup interrupt handler:
+write label:sys_interrupt_handler to REG_SYS_INTERRUPT_HANDLER
+write "" to REG_SYS_INTERRUPT_DATA
+write "-1" to REG_SYS_HW_TIMER
 
 // Print welcome message
 write "RAMFS init - done." to DISPLAY_BUFFER

--- a/src/minion.kga
+++ b/src/minion.kga
@@ -7,29 +7,29 @@ write SYS_CALL_SET_BACKGROUND to REG_D
 write OP_SYS_CALL to REG_OP
 cpu_exec
 
-// Define a bitmap (based on https://pin.it/3WcsRt4xM )
+// Define a bitmap (based on https://pin.it/2NMEPwMLh )
 write "cccccccccccccccccccccccccccc" to 170
 write "cccccccccccccccccccccccccccc" to 171
 write "cccccccccccccccccccccccccccc" to 172
 write "cccccccccccccccccccccccccccc" to 173
-write "cccccccccccrrrrrcccccccccccc" to 174
-write "ccccccccccrrrrrrrrrccccccccc" to 175
-write "ccccccccccbbbyybyccccccccccc" to 176
-write "cccccccccbybyyybyyyccccccccc" to 177
-write "cccccccccbybbyyybyyycccccccc" to 178
-write "cccccccccbbyyyybbbbccccccccc" to 179
-write "cccccccccccyyyyyyycccccccccc" to 180
-write "ccccccccccbbrbbbcccccccccccc" to 181
-write "cccccccccbbbrbbrbbbccccccccc" to 182
-write "ccccccccbbbbrrrrbbbbcccccccc" to 183
-write "ccccccccyybryrryrbyycccccccc" to 184
-write "ccccccccyyyrrrrrryyycccccccc" to 185
-write "ccccccccyyrrrrrrrryycccccccc" to 186
-write "ccccccccccrrrccrrrcccccccccc" to 187
-write "cccccccccbbbccccbbbccccccccc" to 188
-write "ccccccccbbbbccccbbbbcccccccc" to 189
-write "cBBBBBBBBBBBBBBBBBBBBBBBBBBc" to 190
-write "cccccccccccccccccccccccccccc" to 191
+write "ccccccccccyyyyyyycccccccccccc" to 174
+write "cccccccccyyyyyyyyyccccccccccc" to 175
+write "ccccccccyybbyyybbyyccccccccc" to 176
+write "ccccccccBbwBbBbwBbBccccccccc" to 177
+write "ccccccccBbwwbBbwwbBccccccccc" to 178
+write "ccccccccyybbyyybbyyccccccccc" to 179
+write "ccccccccyyyyyyyyyyycccccccccc" to 180
+write "ccccccccyyByyyyyByycccccccccc" to 181
+write "ccccccccyyyBBBBByyycccccccccc" to 182
+write "ccccccccbyyyyyyyyybcccccccccc" to 183
+write "ccccccccybbbbbbbbbycccccccccc" to 184
+write "ccccccccyybbbbbbbyycccccccccc" to 185
+write "ccccccccyybbbbbbbyycccccccccc" to 186
+write "ccccccccybbbbbbbbbycccccccccc" to 187
+write "cccccccBBbbbbbbbbbBBccccccccc" to 188
+write "ccccccccBbbbbbbbbbBcccccccccc" to 189
+write "ccccccccccBBcccBBcccccccccccc" to 190
+write "cccccccccBBBcccBBBccccccccccc" to 191
 write "cccccccccccccccccccccccccccc" to 192
 write "cccccccccccccccccccccccccccc" to 193
 write "cccccccccccccccccccccccccccc" to 194
@@ -122,7 +122,7 @@ label start
         copy REG_RES to var:counter
 
         copy var:counter to REG_A
-        write 191 to REG_B
+        write 192 to REG_B
         write OP_CMP_LT to REG_OP
         cpu_exec
         jump_if label:shift_right


### PR DESCRIPTION
Round-robin scheduler

New process related syscalls added to the table but not implemented yet Refactored sys_sched_run to have a separate function for selection of next process to execute

Implementation of system calls to check whether process is active, kill process if needed, skip current round of scheduling, wait scheduling until all toher processes in state ready will be completed

Add minion program